### PR TITLE
add square-square history table

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -16,6 +16,7 @@ use crate::board::Board;
 use crate::board::r#move::{Move, MoveList, NULL_MOVE};
 use crate::eval::evaluate;
 use crate::search::macros::*;
+use crate::search::tables::HISTORY_MAX;
 use crate::util::helper::{read_param, tuneable_params};
 use crate::util::types::PieceType;
 use crate::util::uci::print_thinking;
@@ -590,7 +591,7 @@ impl Thread<'_> {
                             r -= (is_killer || is_counter) as i32;
 
                             // either increase or decrease reduction depending on history score
-                            r -= self.info.history_table[piece_moved][m.square_to()] / 8192;
+                            r -= self.get_history(m, piece_moved) / (HISTORY_MAX / 2);
                         }
 
                         let reduced_depth = (new_depth as i32 - r).clamp(1, new_depth as i32) as u8;

--- a/src/search/ordering.rs
+++ b/src/search/ordering.rs
@@ -278,7 +278,7 @@ impl Move {
 
             let victim_type = if self.is_en_passant() { PieceType::Pawn } else { piece_type(self.piece_captured(b)) };
             let pc = self.piece_moved(b);
-            let hist = s.info.caphist_table[pc][sq][victim_type];
+            let hist = s.info.caphist[pc][sq][victim_type];
 
             //at high depths we can put more effort into our move ordering because there's a
             //greater reward for optimal order
@@ -302,7 +302,7 @@ impl Move {
             let mut cont_bonus = if s.ply > 0
                 && let Some(prev) = s.info.ss[s.ply - 1].square_moved_to
             {
-                let side = (b.side_to_move == Colour::White) as usize;
+                let side = b.side_to_move;
                 s.info.counter_correlation[side][prev][sq]
             } else {
                 0
@@ -311,7 +311,7 @@ impl Move {
             cont_bonus += if s.ply > 1
                 && let Some(prev) = s.info.ss[s.ply - 2].square_moved_to
             {
-                let side = (b.side_to_move == Colour::White) as usize;
+                let side = b.side_to_move;
                 s.info.followup_correlation[side][prev][sq]
             } else {
                 0
@@ -321,7 +321,8 @@ impl Move {
                 + if s.info.killer_moves[s.ply] == Some(self) {
                     read_param!(FIRST_KILLER_MOVE)
                 } else {
-                    s.info.history_table[self.piece_moved(b)][self.square_to()]
+                    let pc = self.piece_moved(b);
+                    s.get_history(self, pc)
                 }
         }
     }

--- a/src/search/tables.rs
+++ b/src/search/tables.rs
@@ -1,11 +1,11 @@
-use crate::Colour;
 use crate::board::Board;
 use crate::board::r#move::{Move, NULL_MOVE};
 use crate::search::thread::{CORRHIST_SIZE, NodeTable, Thread};
 use crate::search::{INFINITY, MAX_DEPTH};
+use crate::util::Piece;
 use crate::util::helper::piece_type;
 
-const HISTORY_MAX: i32 = 16_384;
+pub const HISTORY_MAX: i32 = 16_384;
 const CORRELATION_MAX: i32 = 4_096;
 
 const CORRHIST_GRAIN: i32 = 256;
@@ -23,6 +23,14 @@ impl Thread<'_> {
             //copy from next row in pv table
         }
         self.pv_length[self.ply] = self.pv_length[next_ply];
+    }
+
+    pub fn get_history(&self, m: Move, pc: Piece) -> i32 {
+        let side = pc.colour();
+        let from = m.square_from();
+        let to = m.square_to();
+
+        self.info.piece_history[pc][to] + self.info.square_history[side][from][to]
     }
 
     pub fn update_search_tables(
@@ -70,7 +78,7 @@ impl Thread<'_> {
             return;
         };
 
-        let side = (b.side_to_move == Colour::White) as usize;
+        let side = b.side_to_move;
 
         if tactical {
             for &m in tacticals {
@@ -128,7 +136,7 @@ impl Thread<'_> {
             self.info.counter_moves[pc][prev] = Some(cutoff_move);
         }
 
-        let side = (b.side_to_move == Colour::White) as usize;
+        let side = b.side_to_move;
 
         if tactical {
             for &m in tacticals {
@@ -164,12 +172,14 @@ impl Thread<'_> {
         tactical: bool,
         depth: u8,
     ) {
-        let bonus = (300 * depth as i32 - 250).clamp(-HISTORY_MAX, HISTORY_MAX);
+        const SHM: i32 = HISTORY_MAX / 2; // max for history entry in a single table
+
+        let bonus = (150 * depth as i32 - 125).clamp(-SHM, SHM);
         //penalise all moves that have been checked and have not caused beta cutoff
 
         let update = |entry: &mut i32, m: Move| {
             let sign = if m == cutoff_move { 1 } else { -1 };
-            let delta = (sign * bonus) - *entry * bonus / HISTORY_MAX;
+            let delta = (sign * bonus) - *entry * bonus / SHM;
             *entry += delta;
         };
 
@@ -180,19 +190,25 @@ impl Thread<'_> {
                     continue;
                 }
                 let piece = m.piece_moved(b);
-                let target = m.square_to();
+                let to = m.square_to();
                 let captured = piece_type(m.piece_captured(b));
 
-                let entry = &mut self.info.caphist_table[piece][target][captured];
+                let entry = &mut self.info.caphist[piece][to][captured];
                 update(entry, m);
             }
         } else {
             // penalise all moves quiets that failed to cause cutoff
             for &m in quiets {
                 let piece = m.piece_moved(b);
-                let target = m.square_to();
+                let to = m.square_to();
+                let from = m.square_from();
 
-                let entry = &mut self.info.history_table[piece][target];
+                let entry = &mut self.info.piece_history[piece][to];
+                update(entry, m);
+
+                let side = b.side_to_move;
+
+                let entry = &mut self.info.square_history[side][from][to];
                 update(entry, m);
             }
 
@@ -201,9 +217,9 @@ impl Thread<'_> {
                     continue;
                 }
                 let piece = m.piece_moved(b);
-                let target = m.square_to();
+                let to = m.square_to();
                 let captured = piece_type(m.piece_captured(b));
-                let entry = &mut self.info.caphist_table[piece][target][captured];
+                let entry = &mut self.info.caphist[piece][to][captured];
                 update(entry, m);
             }
         }
@@ -211,7 +227,7 @@ impl Thread<'_> {
 
     pub fn update_corrhist(&mut self, b: &Board, depth: u8, diff: i32) {
         let idx = b.pawn_hash as usize % CORRHIST_SIZE;
-        let side = b.side_to_move as usize;
+        let side = b.side_to_move;
 
         let entry = &mut self.info.corrhist[side][idx];
 
@@ -225,7 +241,7 @@ impl Thread<'_> {
 
     pub fn eval_with_corrhist(&self, b: &Board, raw_eval: i32) -> i32 {
         let idx = b.pawn_hash as usize % CORRHIST_SIZE;
-        let side = b.side_to_move as usize;
+        let side = b.side_to_move;
 
         let entry = self.info.corrhist[side][idx];
         (raw_eval + entry / CORRHIST_GRAIN).clamp(-MATE + 1, MATE - 1)

--- a/src/search/thread.rs
+++ b/src/search/thread.rs
@@ -49,8 +49,9 @@ pub struct SearchInfo {
     pub ss: [SearchStackEntry; MAX_DEPTH],
     pub lmr_table: LMRTable,
     pub nodetable: NodeTable,
-    pub history_table: [[i32; 64]; 12],
-    pub caphist_table: [[[i32; 5]; 64]; 12],
+    pub piece_history: [[i32; 64]; 12],
+    pub square_history: [[[i32; 64]; 64]; 2],
+    pub caphist: [[[i32; 5]; 64]; 12],
 
     pub counter_correlation: [[[i32; 64]; 64]; 2],
     pub followup_correlation: [[[i32; 64]; 64]; 2],
@@ -168,8 +169,9 @@ impl Default for SearchInfo {
             ss: [SearchStackEntry::default(); MAX_DEPTH],
             lmr_table: LMRTable::default(),
             nodetable: NodeTable::default(),
-            history_table: [[0; 64]; 12],
-            caphist_table: [[[0; 5]; 64]; 12],
+            piece_history: [[0; 64]; 12],
+            square_history: [[[0; 64]; 64]; 2],
+            caphist: [[[0; 5]; 64]; 12],
 
             counter_correlation: [[[0; 64]; 64]; 2],
             followup_correlation: [[[0; 64]; 64]; 2],

--- a/src/util/types.rs
+++ b/src/util/types.rs
@@ -76,6 +76,23 @@ pub const PIECES: [Piece; 12] = [
 pub const WHITE_PIECES: [Piece; 6] = [Piece::WP, Piece::WB, Piece::WN, Piece::WR, Piece::WQ, Piece::WK];
 
 pub const BLACK_PIECES: [Piece; 6] = [Piece::BP, Piece::BB, Piece::BN, Piece::BR, Piece::BQ, Piece::BK];
+
+impl<T> Index<Colour> for [T; 2] {
+    type Output = T;
+
+    fn index(&self, index: Colour) -> &Self::Output {
+        // SAFETY: the legal values for this type are all in bounds.
+        unsafe { self.get_unchecked(index as usize) }
+    }
+}
+
+impl<T> IndexMut<Colour> for [T; 2] {
+    fn index_mut(&mut self, index: Colour) -> &mut Self::Output {
+        // SAFETY: the legal values for this type are all in bounds.
+        unsafe { self.get_unchecked_mut(index as usize) }
+    }
+}
+
 impl<T> Index<Square> for [T; 64] {
     type Output = T;
 


### PR DESCRIPTION
history score of a move (regular history rather than conthist) now depends on sum of 2 tables
- hist[piece][to] as before
- hist[side][from][to] which is new

max value in each of these tables is now half of HISTORY_MAX
also implemented index [T; 2] for Colour enum, which doesn't bring any functional changes